### PR TITLE
feat: Add unit and integration tests for DoctorService and DoctorController

### DIFF
--- a/doctor-microservice/pom.xml
+++ b/doctor-microservice/pom.xml
@@ -47,6 +47,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/doctor-microservice/src/main/java/com/visor/doctor_microservice/advice/GlobalExceptionHandler.java
+++ b/doctor-microservice/src/main/java/com/visor/doctor_microservice/advice/GlobalExceptionHandler.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
 import java.util.stream.Collectors;
 import java.time.Instant;
 
@@ -29,6 +31,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicateResourceException.class)
     public ResponseEntity<ErrorResponse> handleDuplicate(DuplicateResourceException ex) {
         return buildErrorResponse(ex.getMessage(), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+        return buildErrorResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)

--- a/doctor-microservice/src/main/java/com/visor/doctor_microservice/controller/DoctorController.java
+++ b/doctor-microservice/src/main/java/com/visor/doctor_microservice/controller/DoctorController.java
@@ -42,8 +42,12 @@ public class DoctorController {
             security = @SecurityRequirement(name = "security_auth"))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Doctor found"),
+            @ApiResponse(responseCode = "400", description = "Invalid doctor ID",
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"Invalid doctor ID format\"}"))),
             @ApiResponse(responseCode = "404", description = "Doctor not found",
-                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"No active doctor found with ID: 5\"}")))
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"No active doctor found with ID: 5\"}"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected error",
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"Internal Server Error\"}")))
     })
     @GetMapping("/{id}")
     public ResponseEntity<Doctor> getDoctorById(@PathVariable Long id) {
@@ -56,7 +60,9 @@ public class DoctorController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Doctor ID retrieved"),
             @ApiResponse(responseCode = "404", description = "Doctor not found for Keycloak ID",
-                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"No active doctor found with Keycloak ID: abc-123\"}")))
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"No active doctor found with Keycloak ID: abc-123\"}"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected error",
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"Internal Server Error\"}")))
     })
     @GetMapping("/exist/{keycloakId}")
     public ResponseEntity<Long> getDoctorByKeycloakId(@PathVariable String keycloakId) {
@@ -69,7 +75,9 @@ public class DoctorController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Doctor found"),
             @ApiResponse(responseCode = "404", description = "Doctor not found for license",
-                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"No active doctor found with license number: ABC123\"}")))
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"No active doctor found with license number: ABC123\"}"))),
+            @ApiResponse(responseCode = "500", description = "Unexpected error",
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"Internal Server Error\"}")))
     })
     @GetMapping("/license/{licenseNumber}")
     public ResponseEntity<Doctor> getDoctorByLicense(@PathVariable String licenseNumber) {
@@ -83,44 +91,37 @@ public class DoctorController {
             @ApiResponse(responseCode = "200", description = "Doctor updated successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid doctor data",
                     content = @Content(examples = @ExampleObject(value = "{\"message\": \"firstName: must not be blank, email: must be a valid format\"}"))),
-            @ApiResponse(responseCode = "404", description = "Doctor not found")
+            @ApiResponse(responseCode = "403", description = "Forbidden - No JWT token provided or invalid token"),
+            @ApiResponse(responseCode = "404", description = "Doctor not found"),
+            @ApiResponse(responseCode = "500", description = "Unexpected error",
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"Internal Server Error\"}")))
     })
     @PatchMapping
     public ResponseEntity<Doctor> updateDoctor(@Valid @RequestBody Doctor doctor) {
-        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        String keycloakId = ((JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication()).getToken().getSubject();
+        Long idDoctor = doctorService.getDoctorIdByKeycloakId(keycloakId);
 
-        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
-            String keycloakId = jwtAuth.getToken().getSubject();
-            Long idDoctor = doctorService.getDoctorIdByKeycloakId(keycloakId);
+        doctor.setId(idDoctor);
+        doctor.setIdKeycloak(keycloakId);
 
-            doctor.setId(idDoctor);
-            doctor.setIdKeycloak(keycloakId);
-
-            return ResponseEntity.ok(doctorService.patchDoctor(idDoctor, doctor));
-        }
-
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        return ResponseEntity.ok(doctorService.patchDoctor(idDoctor, doctor));
     }
 
     @Operation(summary = "Delete Doctor",
             description = "Deletes the currently authenticated doctor based on the Keycloak token.",
             security = @SecurityRequirement(name = "security_auth"))
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "Doctor deleted successfully"),
-            @ApiResponse(responseCode = "404", description = "Doctor not found")
+            @ApiResponse(responseCode = "200", description = "Doctor deleted successfully"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - No JWT token provided or invalid token"),
+            @ApiResponse(responseCode = "404", description = "Doctor not found"),
+            @ApiResponse(responseCode = "500", description = "Unexpected error",
+                    content = @Content(examples = @ExampleObject(value = "{\"message\": \"Internal Server Error\"}")))
     })
     @DeleteMapping
     public ResponseEntity<Void> deleteDoctor() {
-        var authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication instanceof JwtAuthenticationToken jwtAuth) {
-            String keycloakId = jwtAuth.getToken().getSubject();
+            String keycloakId = ((JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication()).getToken().getSubject();
             Long idDoctor = doctorService.getDoctorIdByKeycloakId(keycloakId);
-
             doctorService.deleteDoctor(idDoctor);
-            return ResponseEntity.noContent().build();
-        }
-
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            return ResponseEntity.ok().build();
     }
 }

--- a/doctor-microservice/src/main/java/com/visor/doctor_microservice/controller/DoctorController.java
+++ b/doctor-microservice/src/main/java/com/visor/doctor_microservice/controller/DoctorController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -98,7 +99,7 @@ public class DoctorController {
             return ResponseEntity.ok(doctorService.patchDoctor(idDoctor, doctor));
         }
 
-        return ResponseEntity.badRequest().build();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 
     @Operation(summary = "Delete Doctor",
@@ -120,6 +121,6 @@ public class DoctorController {
             return ResponseEntity.noContent().build();
         }
 
-        return ResponseEntity.badRequest().build();
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 }

--- a/doctor-microservice/src/main/java/com/visor/doctor_microservice/controller/DoctorController.java
+++ b/doctor-microservice/src/main/java/com/visor/doctor_microservice/controller/DoctorController.java
@@ -98,7 +98,7 @@ public class DoctorController {
             return ResponseEntity.ok(doctorService.patchDoctor(idDoctor, doctor));
         }
 
-        return ResponseEntity.badRequest().build(); // No JWT token
+        return ResponseEntity.badRequest().build();
     }
 
     @Operation(summary = "Delete Doctor",

--- a/doctor-microservice/src/main/java/com/visor/doctor_microservice/entity/Doctor.java
+++ b/doctor-microservice/src/main/java/com/visor/doctor_microservice/entity/Doctor.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class Doctor {
 
     @Id

--- a/doctor-microservice/src/test/java/com/visor/doctor_microservice/controller/DoctorControllerTest.java
+++ b/doctor-microservice/src/test/java/com/visor/doctor_microservice/controller/DoctorControllerTest.java
@@ -1,0 +1,147 @@
+package com.visor.doctor_microservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.visor.doctor_microservice.entity.Doctor;
+import com.visor.doctor_microservice.repository.DoctorRepository;
+import com.visor.doctor_microservice.service.DoctorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = DoctorController.class,
+        excludeAutoConfiguration = {HibernateJpaAutoConfiguration.class, DataSourceAutoConfiguration.class})
+public class DoctorControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DoctorService doctorService;
+
+    @MockitoBean
+    private DoctorRepository doctorRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Doctor sampleDoctor;
+
+    @BeforeEach
+    void setUp() {
+        sampleDoctor = Doctor.builder()
+                .id(1L)
+                .idKeycloak("keycloak-id-123")
+                .firstName("Diego")
+                .lastName("Bustos")
+                .email("diegombustos16@gmail.com")
+                .licenseNumber("ABC123")
+                .build();
+    }
+
+    @Test
+    void shouldGetAllDoctors() throws Exception {
+        when(doctorService.getAllDoctors()).thenReturn(List.of(sampleDoctor));
+
+        mockMvc.perform(get("/api/doctors")
+                        .with(jwt().jwt(jwt -> {
+                            jwt.claim("sub", "keycloak-id-123");
+                            jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
+                        })))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].firstName").value("Diego"));
+    }
+
+    @Test
+    void shouldGetDoctorById() throws Exception {
+        when(doctorService.getDoctorById(1L)).thenReturn(sampleDoctor);
+
+        mockMvc.perform(get("/api/doctors/1")
+                        .with(jwt().jwt(jwt -> {
+                            jwt.claim("sub", "keycloak-id-123");
+                            jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
+                        })))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("diegombustos16@gmail.com"));
+    }
+
+    @Test
+    void shouldGetDoctorByLicense() throws Exception {
+        when(doctorService.getDoctorByLicenseNumber("ABC123")).thenReturn(sampleDoctor);
+
+        mockMvc.perform(get("/api/doctors/license/ABC123")
+                        .with(jwt().jwt(jwt -> {
+                            jwt.claim("sub", "keycloak-id-123");
+                            jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
+                        })))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idKeycloak").value("keycloak-id-123"));
+    }
+
+    @Test
+    void shouldGetDoctorIdByKeycloakId() throws Exception {
+        when(doctorService.getDoctorIdByKeycloakId("keycloak-id-123")).thenReturn(1L);
+
+        mockMvc.perform(get("/api/doctors/exist/keycloak-id-123")
+                        .with(jwt().jwt(jwt -> {
+                            jwt.claim("sub", "keycloak-id-123");
+                            jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
+                        })))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+    }
+
+    @Test
+    void shouldUpdateDoctor() throws Exception {
+        Doctor updatedDoctor = Doctor.builder()
+                .id(1L)
+                .idKeycloak("keycloak-id-123")
+                .licenseNumber("ABC123")
+                .firstName("Updated")
+                .lastName("Bustos")
+                .email("diegombustos16@gmail.com")
+                .build();
+
+        when(doctorService.getDoctorIdByKeycloakId("keycloak-id-123")).thenReturn(1L);
+        when(doctorService.patchDoctor(eq(1L), any(Doctor.class))).thenReturn(updatedDoctor);
+
+        mockMvc.perform(patch("/api/doctors")
+                        .with(jwt().jwt(jwt -> {
+                            jwt.claim("sub", "keycloak-id-123");
+                            jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
+                        }))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedDoctor)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Updated"));
+    }
+
+    @Test
+    void shouldDeleteDoctor() throws Exception {
+        when(doctorService.getDoctorIdByKeycloakId("keycloak-id-123")).thenReturn(1L);
+
+        mockMvc.perform(delete("/api/doctors")
+                        .with(jwt().jwt(jwt -> {
+                            jwt.claim("sub", "keycloak-id-123");
+                            jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
+                        })))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/doctor-microservice/src/test/java/com/visor/doctor_microservice/controller/DoctorControllerTest.java
+++ b/doctor-microservice/src/test/java/com/visor/doctor_microservice/controller/DoctorControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -202,6 +203,14 @@ public class DoctorControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    void shouldReturn403IfNoJwtAuthenticationWhenUpdating() throws Exception {
+        mockMvc.perform(patch("/api/doctors")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(sampleDoctor)))
+                .andExpect(status().isForbidden());
+    }
+
     // --- DELETE /api/doctors ---
 
     @Test
@@ -227,5 +236,11 @@ public class DoctorControllerTest {
                             jwt.claim("realm_access", Map.of("roles", List.of("DOCTOR")));
                         })))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn403IfNoJwtAuthenticationWhenDeleting() throws Exception {
+        mockMvc.perform(delete("/api/doctors"))
+                .andExpect(status().isForbidden());
     }
 }

--- a/doctor-microservice/src/test/java/com/visor/doctor_microservice/service/DoctorServiceTest.java
+++ b/doctor-microservice/src/test/java/com/visor/doctor_microservice/service/DoctorServiceTest.java
@@ -46,6 +46,7 @@ public class DoctorServiceTest {
                 .build();
     }
 
+    // POST /doctors
     @Test
     void createDoctor_shouldReturnDoctor_whenSuccessful() {
         when(doctorRepository.save(doctor)).thenReturn(doctor);
@@ -59,6 +60,7 @@ public class DoctorServiceTest {
         assertThrows(DuplicateResourceException.class, () -> doctorService.createDoctor(doctor));
     }
 
+    // GET /doctors
     @Test
     void getAllDoctors_shouldReturnList() {
         when(doctorRepository.findAllByDeletedAtIsNull()).thenReturn(List.of(doctor));
@@ -67,6 +69,7 @@ public class DoctorServiceTest {
         assertEquals("Diego", result.get(0).getFirstName());
     }
 
+    // GET /doctors/{id}
     @Test
     void getDoctorById_shouldReturnDoctor() {
         when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
@@ -80,6 +83,7 @@ public class DoctorServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorById(1L));
     }
 
+    // GET /doctors/license/{licenseNumber}
     @Test
     void getDoctorByLicenseNumber_shouldReturnDoctor() {
         when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("LIC123")).thenReturn(Optional.of(doctor));
@@ -93,6 +97,7 @@ public class DoctorServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorByLicenseNumber("XYZ"));
     }
 
+    // GET /doctors/keycloak/{idKeycloak}
     @Test
     void getDoctorIdByKeycloakId_shouldReturnId() {
         when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("keycloak-id")).thenReturn(Optional.of(doctor));
@@ -106,6 +111,7 @@ public class DoctorServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorIdByKeycloakId("wrong-id"));
     }
 
+    // PATCH /doctors/{id}
     @Test
     void patchDoctor_shouldUpdateNonNullFields() {
         Doctor partial = new Doctor();
@@ -124,6 +130,7 @@ public class DoctorServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> doctorService.patchDoctor(1L, new Doctor()));
     }
 
+    // DELETE /doctors/{id}
     @Test
     void deleteDoctor_shouldSetDeletedAt() {
         when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));

--- a/doctor-microservice/src/test/java/com/visor/doctor_microservice/service/DoctorServiceTest.java
+++ b/doctor-microservice/src/test/java/com/visor/doctor_microservice/service/DoctorServiceTest.java
@@ -5,6 +5,8 @@ import com.visor.doctor_microservice.exception.DuplicateResourceException;
 import com.visor.doctor_microservice.exception.ResourceNotFoundException;
 import com.visor.doctor_microservice.repository.DoctorRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,8 +18,11 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+
 
 @ExtendWith(MockitoExtension.class)
 public class DoctorServiceTest {
@@ -46,102 +51,165 @@ public class DoctorServiceTest {
                 .build();
     }
 
-    // POST /doctors
-    @Test
-    void createDoctor_shouldReturnDoctor_whenSuccessful() {
-        when(doctorRepository.save(doctor)).thenReturn(doctor);
-        Doctor result = doctorService.createDoctor(doctor);
-        assertEquals("Diego", result.getFirstName());
+    @Nested
+    @DisplayName("Create Doctor")
+    class CreateDoctorTests {
+
+        @Test
+        @DisplayName("should return saved doctor when successful")
+        void createDoctor_shouldReturnDoctor_whenSuccessful() {
+            when(doctorRepository.save(doctor)).thenReturn(doctor);
+
+            Doctor result = doctorService.createDoctor(doctor);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getFirstName()).isEqualTo("Diego");
+            verify(doctorRepository, times(1)).save(doctor);
+        }
+
+        @Test
+        @DisplayName("should throw DuplicateResourceException when keycloakId already exists")
+        void createDoctor_shouldThrowDuplicateResourceException_whenDuplicateKeycloakId() {
+            when(doctorRepository.save(doctor)).thenThrow(new org.springframework.dao.DataIntegrityViolationException("Duplicate"));
+
+            assertThrows(DuplicateResourceException.class, () -> doctorService.createDoctor(doctor));
+            verify(doctorRepository, times(1)).save(doctor);
+        }
     }
 
-    @Test
-    void createDoctor_shouldThrow_whenDuplicateKeycloakId() {
-        when(doctorRepository.save(doctor)).thenThrow(new org.springframework.dao.DataIntegrityViolationException("Duplicate"));
-        assertThrows(DuplicateResourceException.class, () -> doctorService.createDoctor(doctor));
+    @Nested
+    @DisplayName("Get Doctors")
+    class GetDoctorsTests {
+
+        @Test
+        @DisplayName("should return list of doctors")
+        void getAllDoctors_shouldReturnList() {
+            when(doctorRepository.findAllByDeletedAtIsNull()).thenReturn(List.of(doctor));
+
+            List<Doctor> result = doctorService.getAllDoctors();
+
+            assertThat(result)
+                    .asInstanceOf(LIST)
+                    .hasSize(1);
+            assertThat(result.get(0).getFirstName()).isEqualTo("Diego");
+            verify(doctorRepository, times(1)).findAllByDeletedAtIsNull();
+        }
+
+        @Test
+        @DisplayName("should return doctor by ID")
+        void getDoctorById_shouldReturnDoctor() {
+            when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
+
+            Doctor result = doctorService.getDoctorById(1L);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            verify(doctorRepository, times(1)).findByIdAndDeletedAtIsNull(1L);
+        }
+
+        @Test
+        @DisplayName("should throw ResourceNotFoundException when doctor by ID not found")
+        void getDoctorById_shouldThrow_whenNotFound() {
+            when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorById(1L));
+            verify(doctorRepository, times(1)).findByIdAndDeletedAtIsNull(1L);
+        }
+
+        @Test
+        @DisplayName("should return doctor by License Number")
+        void getDoctorByLicenseNumber_shouldReturnDoctor() {
+            when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("LIC123")).thenReturn(Optional.of(doctor));
+
+            Doctor result = doctorService.getDoctorByLicenseNumber("LIC123");
+
+            assertThat(result).isNotNull();
+            assertThat(result.getLicenseNumber()).isEqualTo("LIC123");
+            verify(doctorRepository, times(1)).findByLicenseNumberAndDeletedAtIsNull("LIC123");
+        }
+
+        @Test
+        @DisplayName("should throw ResourceNotFoundException when license number not found")
+        void getDoctorByLicenseNumber_shouldThrow_whenNotFound() {
+            when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("XYZ")).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorByLicenseNumber("XYZ"));
+            verify(doctorRepository, times(1)).findByLicenseNumberAndDeletedAtIsNull("XYZ");
+        }
+
+        @Test
+        @DisplayName("should return doctor ID by Keycloak ID")
+        void getDoctorIdByKeycloakId_shouldReturnId() {
+            when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("keycloak-id")).thenReturn(Optional.of(doctor));
+
+            Long id = doctorService.getDoctorIdByKeycloakId("keycloak-id");
+
+            assertThat(id).isEqualTo(1L);
+            verify(doctorRepository, times(1)).findByIdKeycloakAndDeletedAtIsNull("keycloak-id");
+        }
+
+        @Test
+        @DisplayName("should throw ResourceNotFoundException when Keycloak ID not found")
+        void getDoctorIdByKeycloakId_shouldThrow_whenNotFound() {
+            when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("wrong-id")).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorIdByKeycloakId("wrong-id"));
+            verify(doctorRepository, times(1)).findByIdKeycloakAndDeletedAtIsNull("wrong-id");
+        }
     }
 
-    // GET /doctors
-    @Test
-    void getAllDoctors_shouldReturnList() {
-        when(doctorRepository.findAllByDeletedAtIsNull()).thenReturn(List.of(doctor));
-        List<Doctor> result = doctorService.getAllDoctors();
-        assertEquals(1, result.size());
-        assertEquals("Diego", result.get(0).getFirstName());
+    @Nested
+    @DisplayName("Patch Doctor")
+    class PatchDoctorTests {
+
+        @Test
+        @DisplayName("should update non-null fields of doctor")
+        void patchDoctor_shouldUpdateFields() {
+            Doctor partial = new Doctor();
+            partial.setFirstName("UpdatedName");
+
+            when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
+            when(doctorRepository.save(any(Doctor.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            Doctor updated = doctorService.patchDoctor(1L, partial);
+
+            assertThat(updated.getFirstName()).isEqualTo("UpdatedName");
+            assertThat(updated.getLastName()).isEqualTo("Bustos"); // unchanged field
+            verify(doctorRepository, times(1)).save(doctor);
+        }
+
+        @Test
+        @DisplayName("should throw ResourceNotFoundException when doctor to patch not found")
+        void patchDoctor_shouldThrow_whenNotFound() {
+            when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> doctorService.patchDoctor(1L, new Doctor()));
+            verify(doctorRepository, never()).save(any(Doctor.class));
+        }
     }
 
-    // GET /doctors/{id}
-    @Test
-    void getDoctorById_shouldReturnDoctor() {
-        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
-        Doctor result = doctorService.getDoctorById(1L);
-        assertEquals("Diego", result.getFirstName());
+    @Nested
+    @DisplayName("Delete Doctor")
+    class DeleteDoctor {
+
+        @Test
+        @DisplayName("should set deletedAt and save the doctor when found")
+        void shouldSetDeletedAtAndSaveDoctorWhenFound() {
+            when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
+
+            doctorService.deleteDoctor(1L);
+
+            assertNotNull(doctor.getDeletedAt());
+            verify(doctorRepository).save(doctor);
+        }
+
+        @Test
+        @DisplayName("should throw ResourceNotFoundException when doctor not found")
+        void shouldThrowExceptionWhenDoctorNotFound() {
+            when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+            assertThrows(ResourceNotFoundException.class, () -> doctorService.deleteDoctor(1L));
+        }
     }
 
-    @Test
-    void getDoctorById_shouldThrow_whenNotFound() {
-        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-        assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorById(1L));
-    }
-
-    // GET /doctors/license/{licenseNumber}
-    @Test
-    void getDoctorByLicenseNumber_shouldReturnDoctor() {
-        when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("LIC123")).thenReturn(Optional.of(doctor));
-        Doctor result = doctorService.getDoctorByLicenseNumber("LIC123");
-        assertEquals("Diego", result.getFirstName());
-    }
-
-    @Test
-    void getDoctorByLicenseNumber_shouldThrow_whenNotFound() {
-        when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("XYZ")).thenReturn(Optional.empty());
-        assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorByLicenseNumber("XYZ"));
-    }
-
-    // GET /doctors/keycloak/{idKeycloak}
-    @Test
-    void getDoctorIdByKeycloakId_shouldReturnId() {
-        when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("keycloak-id")).thenReturn(Optional.of(doctor));
-        Long id = doctorService.getDoctorIdByKeycloakId("keycloak-id");
-        assertEquals(1L, id);
-    }
-
-    @Test
-    void getDoctorIdByKeycloakId_shouldThrow_whenNotFound() {
-        when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("wrong-id")).thenReturn(Optional.empty());
-        assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorIdByKeycloakId("wrong-id"));
-    }
-
-    // PATCH /doctors/{id}
-    @Test
-    void patchDoctor_shouldUpdateNonNullFields() {
-        Doctor partial = new Doctor();
-        partial.setFirstName("NotDiego");
-
-        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
-        when(doctorRepository.save(any(Doctor.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-        Doctor updated = doctorService.patchDoctor(1L, partial);
-        assertEquals("NotDiego", updated.getFirstName());
-    }
-
-    @Test
-    void patchDoctor_shouldThrow_whenNotFound() {
-        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-        assertThrows(ResourceNotFoundException.class, () -> doctorService.patchDoctor(1L, new Doctor()));
-    }
-
-    // DELETE /doctors/{id}
-    @Test
-    void deleteDoctor_shouldSetDeletedAt() {
-        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
-        doctorService.deleteDoctor(1L);
-        assertNotNull(doctor.getDeletedAt());
-        verify(doctorRepository).save(doctor);
-    }
-
-    @Test
-    void deleteDoctor_shouldThrow_whenNotFound() {
-        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
-        assertThrows(ResourceNotFoundException.class, () -> doctorService.deleteDoctor(1L));
-    }
 }

--- a/doctor-microservice/src/test/java/com/visor/doctor_microservice/service/DoctorServiceTest.java
+++ b/doctor-microservice/src/test/java/com/visor/doctor_microservice/service/DoctorServiceTest.java
@@ -1,0 +1,140 @@
+package com.visor.doctor_microservice.service;
+
+import com.visor.doctor_microservice.entity.Doctor;
+import com.visor.doctor_microservice.exception.DuplicateResourceException;
+import com.visor.doctor_microservice.exception.ResourceNotFoundException;
+import com.visor.doctor_microservice.repository.DoctorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class DoctorServiceTest {
+
+    @InjectMocks
+    private DoctorService doctorService;
+
+    @Mock
+    private DoctorRepository doctorRepository;
+
+    private Doctor doctor;
+
+    @BeforeEach
+    void setUp() {
+        doctor = Doctor.builder()
+                .id(1L)
+                .idKeycloak("keycloak-id")
+                .licenseNumber("LIC123")
+                .firstName("Diego")
+                .lastName("Bustos")
+                .dateOfBirth(LocalDate.of(2000, 2, 16))
+                .gender("Male")
+                .email("diego@example.com")
+                .phoneNumber("+54912345678")
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    void createDoctor_shouldReturnDoctor_whenSuccessful() {
+        when(doctorRepository.save(doctor)).thenReturn(doctor);
+        Doctor result = doctorService.createDoctor(doctor);
+        assertEquals("Diego", result.getFirstName());
+    }
+
+    @Test
+    void createDoctor_shouldThrow_whenDuplicateKeycloakId() {
+        when(doctorRepository.save(doctor)).thenThrow(new org.springframework.dao.DataIntegrityViolationException("Duplicate"));
+        assertThrows(DuplicateResourceException.class, () -> doctorService.createDoctor(doctor));
+    }
+
+    @Test
+    void getAllDoctors_shouldReturnList() {
+        when(doctorRepository.findAllByDeletedAtIsNull()).thenReturn(List.of(doctor));
+        List<Doctor> result = doctorService.getAllDoctors();
+        assertEquals(1, result.size());
+        assertEquals("Diego", result.get(0).getFirstName());
+    }
+
+    @Test
+    void getDoctorById_shouldReturnDoctor() {
+        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
+        Doctor result = doctorService.getDoctorById(1L);
+        assertEquals("Diego", result.getFirstName());
+    }
+
+    @Test
+    void getDoctorById_shouldThrow_whenNotFound() {
+        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorById(1L));
+    }
+
+    @Test
+    void getDoctorByLicenseNumber_shouldReturnDoctor() {
+        when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("LIC123")).thenReturn(Optional.of(doctor));
+        Doctor result = doctorService.getDoctorByLicenseNumber("LIC123");
+        assertEquals("Diego", result.getFirstName());
+    }
+
+    @Test
+    void getDoctorByLicenseNumber_shouldThrow_whenNotFound() {
+        when(doctorRepository.findByLicenseNumberAndDeletedAtIsNull("XYZ")).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorByLicenseNumber("XYZ"));
+    }
+
+    @Test
+    void getDoctorIdByKeycloakId_shouldReturnId() {
+        when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("keycloak-id")).thenReturn(Optional.of(doctor));
+        Long id = doctorService.getDoctorIdByKeycloakId("keycloak-id");
+        assertEquals(1L, id);
+    }
+
+    @Test
+    void getDoctorIdByKeycloakId_shouldThrow_whenNotFound() {
+        when(doctorRepository.findByIdKeycloakAndDeletedAtIsNull("wrong-id")).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> doctorService.getDoctorIdByKeycloakId("wrong-id"));
+    }
+
+    @Test
+    void patchDoctor_shouldUpdateNonNullFields() {
+        Doctor partial = new Doctor();
+        partial.setFirstName("NotDiego");
+
+        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
+        when(doctorRepository.save(any(Doctor.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Doctor updated = doctorService.patchDoctor(1L, partial);
+        assertEquals("NotDiego", updated.getFirstName());
+    }
+
+    @Test
+    void patchDoctor_shouldThrow_whenNotFound() {
+        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> doctorService.patchDoctor(1L, new Doctor()));
+    }
+
+    @Test
+    void deleteDoctor_shouldSetDeletedAt() {
+        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(doctor));
+        doctorService.deleteDoctor(1L);
+        assertNotNull(doctor.getDeletedAt());
+        verify(doctorRepository).save(doctor);
+    }
+
+    @Test
+    void deleteDoctor_shouldThrow_whenNotFound() {
+        when(doctorRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+        assertThrows(ResourceNotFoundException.class, () -> doctorService.deleteDoctor(1L));
+    }
+}


### PR DESCRIPTION
Comprehensive test coverage for the `DoctorService` and `DoctorController` classes.

1. DoctorServiceTest
- Full unit test coverage for all public methods in DoctorService.
- Utilizes Mockito to mock DoctorRepository.
- Tested scenarios:
  - createDoctor: verifies correct persistence and throws DuplicateResourceException on duplicate idKeycloak.
  - getAllDoctors: returns non-deleted doctors using deletedAt IS NULL filter.
  - getDoctorById and getDoctorByLicenseNumber: validates successful fetch and throws ResourceNotFoundException when absent.
  - getDoctorIdByKeycloakId: resolves idKeycloak to id, with exception handling for missing values.
  - patchDoctor: updates only non-null fields and throws ResourceNotFoundException when ID not found.
  - deleteDoctor: performs soft delete (sets deletedAt) and validates repository interaction; throws if doctor is not found.

2. DoctorControllerTest
- Integration tests for controller layer using @WebMvcTest.
- JWT authentication is mocked via with(jwt()), simulating sub and realm_access (role: DOCTOR).
- Covered endpoints:
  - GET /api/doctors: returns all doctors.
  - GET /api/doctors/{id}: fetches doctor by ID.
  - GET /api/doctors/license/{licenseNumber}: fetches by license number.
  - GET /api/doctors/exist/{keycloakId}: fetches doctor ID from idKeycloak.
  - PATCH /api/doctors: partial update based on provided fields.
  - DELETE /api/doctors: performs logical delete based on idKeycloak.

These tests ensure correct service behavior under both expected and exceptional conditions and validate the controller's response logic and authorization context.