### PR TITLE
fix: microservices detection by replacing grep with sed

### DIFF
--- a/.github/workflows/test-microservices.yml
+++ b/.github/workflows/test-microservices.yml
@@ -48,8 +48,8 @@ jobs:
             exit 0
           fi
 
-          services=$(echo "$modified_files" | grep -oE '^[^/]+(?=/)' | sort -u | grep -E '.+-microservice$' | uniq | tr '\n' ' ')
-
+          services=$(echo "$modified_files" | sed -n 's|^\([^/]*\)/.*|\1|p' | sort -u | grep -E '.+-microservice$' | uniq | tr '\n' ' ')
+         
           echo "Detected services: $services"
           echo "services=$services" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
replaces the grep command with a sed expression that correctly captures the first directory from the modified file paths.